### PR TITLE
optimizer

### DIFF
--- a/aliyun-oss-sdk.sln
+++ b/aliyun-oss-sdk.sln
@@ -1,14 +1,14 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 11.00
 # Visual Studio 2010
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "aliyun-oss-sdk", "sdk\aliyun-oss-sdk.csproj", "{67BDC800-084C-4F84-8A80-661B5AFE499A}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "aliyun-oss-sdk", "sdk\aliyun-oss-sdk.csproj", "{EE5D6175-F4A8-4820-B657-69AA4E23ABA5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "aliyun-oss-sdk-samples", "samples\aliyun-oss-sdk-samples.csproj", "{ADC5BCC2-3677-4CD5-9ED3-5BBA427519DD}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "aliyun-oss-sdk-samples", "samples\aliyun-oss-sdk-samples.csproj", "{810508AC-F8F1-4DCE-A50F-F54CD96A3DAB}"
 	ProjectSection(ProjectDependencies) = postProject
-		{67BDC800-084C-4F84-8A80-661B5AFE499A} = {67BDC800-084C-4F84-8A80-661B5AFE499A}
+		{EE5D6175-F4A8-4820-B657-69AA4E23ABA5} = {EE5D6175-F4A8-4820-B657-69AA4E23ABA5}
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "aliyun-oss-sdk-test", "test\aliyun-oss-sdk-test.csproj", "{597D1FDD-CC1D-41CB-B914-A9F60486D9DC}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "aliyun-oss-sdk-test", "test\aliyun-oss-sdk-test.csproj", "{AFDCA7E3-F277-4DF8-BD16-227F235935A7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -18,26 +18,26 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{597D1FDD-CC1D-41CB-B914-A9F60486D9DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{597D1FDD-CC1D-41CB-B914-A9F60486D9DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{597D1FDD-CC1D-41CB-B914-A9F60486D9DC}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{597D1FDD-CC1D-41CB-B914-A9F60486D9DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{597D1FDD-CC1D-41CB-B914-A9F60486D9DC}.Release|Any CPU.Build.0 = Release|Any CPU
-		{597D1FDD-CC1D-41CB-B914-A9F60486D9DC}.Release|x86.ActiveCfg = Release|Any CPU
-		{67BDC800-084C-4F84-8A80-661B5AFE499A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{67BDC800-084C-4F84-8A80-661B5AFE499A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{67BDC800-084C-4F84-8A80-661B5AFE499A}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{67BDC800-084C-4F84-8A80-661B5AFE499A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{67BDC800-084C-4F84-8A80-661B5AFE499A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{67BDC800-084C-4F84-8A80-661B5AFE499A}.Release|x86.ActiveCfg = Release|Any CPU
-		{ADC5BCC2-3677-4CD5-9ED3-5BBA427519DD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{ADC5BCC2-3677-4CD5-9ED3-5BBA427519DD}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{ADC5BCC2-3677-4CD5-9ED3-5BBA427519DD}.Debug|x86.ActiveCfg = Debug|x86
-		{ADC5BCC2-3677-4CD5-9ED3-5BBA427519DD}.Debug|x86.Build.0 = Debug|x86
-		{ADC5BCC2-3677-4CD5-9ED3-5BBA427519DD}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{ADC5BCC2-3677-4CD5-9ED3-5BBA427519DD}.Release|Any CPU.Build.0 = Release|Any CPU
-		{ADC5BCC2-3677-4CD5-9ED3-5BBA427519DD}.Release|x86.ActiveCfg = Release|x86
-		{ADC5BCC2-3677-4CD5-9ED3-5BBA427519DD}.Release|x86.Build.0 = Release|x86
+		{AFDCA7E3-F277-4DF8-BD16-227F235935A7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AFDCA7E3-F277-4DF8-BD16-227F235935A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AFDCA7E3-F277-4DF8-BD16-227F235935A7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AFDCA7E3-F277-4DF8-BD16-227F235935A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AFDCA7E3-F277-4DF8-BD16-227F235935A7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AFDCA7E3-F277-4DF8-BD16-227F235935A7}.Release|x86.ActiveCfg = Release|Any CPU
+		{EE5D6175-F4A8-4820-B657-69AA4E23ABA5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EE5D6175-F4A8-4820-B657-69AA4E23ABA5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EE5D6175-F4A8-4820-B657-69AA4E23ABA5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EE5D6175-F4A8-4820-B657-69AA4E23ABA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EE5D6175-F4A8-4820-B657-69AA4E23ABA5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EE5D6175-F4A8-4820-B657-69AA4E23ABA5}.Release|x86.ActiveCfg = Release|Any CPU
+		{810508AC-F8F1-4DCE-A50F-F54CD96A3DAB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{810508AC-F8F1-4DCE-A50F-F54CD96A3DAB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{810508AC-F8F1-4DCE-A50F-F54CD96A3DAB}.Debug|x86.ActiveCfg = Debug|x86
+		{810508AC-F8F1-4DCE-A50F-F54CD96A3DAB}.Debug|x86.Build.0 = Debug|x86
+		{810508AC-F8F1-4DCE-A50F-F54CD96A3DAB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{810508AC-F8F1-4DCE-A50F-F54CD96A3DAB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{810508AC-F8F1-4DCE-A50F-F54CD96A3DAB}.Release|x86.ActiveCfg = Release|x86
+		{810508AC-F8F1-4DCE-A50F-F54CD96A3DAB}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = samples\aliyun-oss-sdk-samples.csproj

--- a/aliyun-oss-sdk.sln
+++ b/aliyun-oss-sdk.sln
@@ -1,14 +1,14 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 11.00
 # Visual Studio 2010
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "aliyun-oss-sdk", "sdk\aliyun-oss-sdk.csproj", "{EE5D6175-F4A8-4820-B657-69AA4E23ABA5}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "aliyun-oss-sdk", "sdk\aliyun-oss-sdk.csproj", "{67BDC800-084C-4F84-8A80-661B5AFE499A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "aliyun-oss-sdk-samples", "samples\aliyun-oss-sdk-samples.csproj", "{810508AC-F8F1-4DCE-A50F-F54CD96A3DAB}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "aliyun-oss-sdk-samples", "samples\aliyun-oss-sdk-samples.csproj", "{ADC5BCC2-3677-4CD5-9ED3-5BBA427519DD}"
 	ProjectSection(ProjectDependencies) = postProject
-		{EE5D6175-F4A8-4820-B657-69AA4E23ABA5} = {EE5D6175-F4A8-4820-B657-69AA4E23ABA5}
+		{67BDC800-084C-4F84-8A80-661B5AFE499A} = {67BDC800-084C-4F84-8A80-661B5AFE499A}
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "aliyun-oss-sdk-test", "test\aliyun-oss-sdk-test.csproj", "{AFDCA7E3-F277-4DF8-BD16-227F235935A7}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "aliyun-oss-sdk-test", "test\aliyun-oss-sdk-test.csproj", "{597D1FDD-CC1D-41CB-B914-A9F60486D9DC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -18,26 +18,26 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{AFDCA7E3-F277-4DF8-BD16-227F235935A7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{AFDCA7E3-F277-4DF8-BD16-227F235935A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{AFDCA7E3-F277-4DF8-BD16-227F235935A7}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{AFDCA7E3-F277-4DF8-BD16-227F235935A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{AFDCA7E3-F277-4DF8-BD16-227F235935A7}.Release|Any CPU.Build.0 = Release|Any CPU
-		{AFDCA7E3-F277-4DF8-BD16-227F235935A7}.Release|x86.ActiveCfg = Release|Any CPU
-		{EE5D6175-F4A8-4820-B657-69AA4E23ABA5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EE5D6175-F4A8-4820-B657-69AA4E23ABA5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EE5D6175-F4A8-4820-B657-69AA4E23ABA5}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{EE5D6175-F4A8-4820-B657-69AA4E23ABA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EE5D6175-F4A8-4820-B657-69AA4E23ABA5}.Release|Any CPU.Build.0 = Release|Any CPU
-		{EE5D6175-F4A8-4820-B657-69AA4E23ABA5}.Release|x86.ActiveCfg = Release|Any CPU
-		{810508AC-F8F1-4DCE-A50F-F54CD96A3DAB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{810508AC-F8F1-4DCE-A50F-F54CD96A3DAB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{810508AC-F8F1-4DCE-A50F-F54CD96A3DAB}.Debug|x86.ActiveCfg = Debug|x86
-		{810508AC-F8F1-4DCE-A50F-F54CD96A3DAB}.Debug|x86.Build.0 = Debug|x86
-		{810508AC-F8F1-4DCE-A50F-F54CD96A3DAB}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{810508AC-F8F1-4DCE-A50F-F54CD96A3DAB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{810508AC-F8F1-4DCE-A50F-F54CD96A3DAB}.Release|x86.ActiveCfg = Release|x86
-		{810508AC-F8F1-4DCE-A50F-F54CD96A3DAB}.Release|x86.Build.0 = Release|x86
+		{597D1FDD-CC1D-41CB-B914-A9F60486D9DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{597D1FDD-CC1D-41CB-B914-A9F60486D9DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{597D1FDD-CC1D-41CB-B914-A9F60486D9DC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{597D1FDD-CC1D-41CB-B914-A9F60486D9DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{597D1FDD-CC1D-41CB-B914-A9F60486D9DC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{597D1FDD-CC1D-41CB-B914-A9F60486D9DC}.Release|x86.ActiveCfg = Release|Any CPU
+		{67BDC800-084C-4F84-8A80-661B5AFE499A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{67BDC800-084C-4F84-8A80-661B5AFE499A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{67BDC800-084C-4F84-8A80-661B5AFE499A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{67BDC800-084C-4F84-8A80-661B5AFE499A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{67BDC800-084C-4F84-8A80-661B5AFE499A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{67BDC800-084C-4F84-8A80-661B5AFE499A}.Release|x86.ActiveCfg = Release|Any CPU
+		{ADC5BCC2-3677-4CD5-9ED3-5BBA427519DD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ADC5BCC2-3677-4CD5-9ED3-5BBA427519DD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ADC5BCC2-3677-4CD5-9ED3-5BBA427519DD}.Debug|x86.ActiveCfg = Debug|x86
+		{ADC5BCC2-3677-4CD5-9ED3-5BBA427519DD}.Debug|x86.Build.0 = Debug|x86
+		{ADC5BCC2-3677-4CD5-9ED3-5BBA427519DD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ADC5BCC2-3677-4CD5-9ED3-5BBA427519DD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ADC5BCC2-3677-4CD5-9ED3-5BBA427519DD}.Release|x86.ActiveCfg = Release|x86
+		{ADC5BCC2-3677-4CD5-9ED3-5BBA427519DD}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = samples\aliyun-oss-sdk-samples.csproj

--- a/samples/Program.cs
+++ b/samples/Program.cs
@@ -12,7 +12,7 @@ namespace Aliyun.OSS.Samples
         {
             Console.WriteLine("Aliyun SDK for .NET Samples!");
 
-            const string bucketName = "csharp-sdk-test-bucket";
+            const string bucketName = "<your bucket name>";
 
             try
             {

--- a/samples/Samples/ModifyObjectMetaSample.cs
+++ b/samples/Samples/ModifyObjectMetaSample.cs
@@ -32,12 +32,17 @@ namespace Aliyun.OSS.Samples
 
                 client.PutObject(bucketName, key, stream);
 
-                var meta = new ObjectMetadata()
+                var oldMeta = client.GetObjectMetadata(bucketName, key);
+
+                var newMeta = new ObjectMetadata()
                 {
-                    ContentType = "application/msword"
+                    ContentType = "application/msword",
+                    ExpirationTime = oldMeta.ExpirationTime,
+                    ContentEncoding = null,
+                    CacheControl = ""
                 };
 
-                client.ModifyObjectMeta(bucketName, key, meta);
+                client.ModifyObjectMeta(bucketName, key, newMeta);
 
                 Console.WriteLine("Modify object meta succeeded");
             }

--- a/samples/Samples/PutObjectSample.cs
+++ b/samples/Samples/PutObjectSample.cs
@@ -113,13 +113,13 @@ namespace Aliyun.OSS.Samples
         {
             const string key = "PutObjectWithMd5";
 
-            string eTag;
+            string md5;
             using (var fs = File.Open(fileToUpload, FileMode.Open))
             {
-                eTag = OssUtils.ComputeContentMd5(fs, fs.Length);
+                md5 = OssUtils.ComputeContentMd5(fs, fs.Length);
             }
 
-            var meta = new ObjectMetadata() { ETag = eTag };
+            var meta = new ObjectMetadata() { ContentMd5 = md5 };
             try
             {
                 client.PutObject(bucketName, key, fileToUpload, meta);

--- a/samples/aliyun-oss-sdk-samples.csproj
+++ b/samples/aliyun-oss-sdk-samples.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <PropertyGroup>
-    <ProjectGuid>{810508AC-F8F1-4DCE-A50F-F54CD96A3DAB}</ProjectGuid>
+    <ProjectGuid>{ADC5BCC2-3677-4CD5-9ED3-5BBA427519DD}</ProjectGuid>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <OutputType>Exe</OutputType>
@@ -71,6 +71,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <PlatformTarget>AnyCPU</PlatformTarget>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/samples/aliyun-oss-sdk-samples.csproj
+++ b/samples/aliyun-oss-sdk-samples.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <PropertyGroup>
-    <ProjectGuid>{ADC5BCC2-3677-4CD5-9ED3-5BBA427519DD}</ProjectGuid>
+    <ProjectGuid>{810508AC-F8F1-4DCE-A50F-F54CD96A3DAB}</ProjectGuid>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <OutputType>Exe</OutputType>

--- a/sdk/Common/Communication/RetryableServiceClient.cs
+++ b/sdk/Common/Communication/RetryableServiceClient.cs
@@ -56,7 +56,7 @@ namespace Aliyun.OSS.Common.Communication
 
         public ServiceResponse Send(ServiceRequest request, ExecutionContext context)
         {
-            return SendImpl(request, context, MaxRetryTimes);
+            return SendImpl(request, context, 0);
         }
 
         private ServiceResponse SendImpl(ServiceRequest request, ExecutionContext context, int retryTimes)

--- a/sdk/Domain/CopyObjectRequest.cs
+++ b/sdk/Domain/CopyObjectRequest.cs
@@ -84,6 +84,9 @@ namespace Aliyun.OSS
         public CopyObjectRequest(string sourceBucketName, string sourceKey,
             string destinationBucketName, string destinationKey)
         {
+            OssUtils.CheckBucketName(destinationBucketName);
+            OssUtils.CheckObjectKey(destinationKey);
+
             SourceBucketName = sourceBucketName;
             SourceKey = sourceKey;
             DestinationBucketName = destinationBucketName;

--- a/sdk/Domain/ObjectMetadata.cs
+++ b/sdk/Domain/ObjectMetadata.cs
@@ -72,10 +72,7 @@ namespace Aliyun.OSS
             }
             set
             {
-                if (value != null)
-                {
-                    _metadata[HttpHeaders.Expires] = DateUtils.FormatRfc822Date(value);
-                }
+                _metadata[HttpHeaders.Expires] = DateUtils.FormatRfc822Date(value);
             }
         }
 

--- a/sdk/Domain/ObjectMetadata.cs
+++ b/sdk/Domain/ObjectMetadata.cs
@@ -62,18 +62,20 @@ namespace Aliyun.OSS
 
         /// <summary>
         /// 获取Expires请求头，表示Object的过期时间。
-        /// 如果Object没有定义过期时间，则返回null。
         /// </summary>
         public DateTime ExpirationTime
         {
             get
             {
                 return _metadata.ContainsKey(HttpHeaders.Expires)
-                     ? (DateTime)_metadata[HttpHeaders.Expires] : DateTime.MinValue;
+                     ? DateUtils.ParseRfc822Date((string)_metadata[HttpHeaders.Expires]) : DateTime.MinValue;
             }
             set
             {
-                _metadata[HttpHeaders.Expires] = value;
+                if (value != null)
+                {
+                    _metadata[HttpHeaders.Expires] = DateUtils.FormatRfc822Date(value);
+                }
             }
         }
 
@@ -107,7 +109,10 @@ namespace Aliyun.OSS
             }
             set
             {
-                _metadata[HttpHeaders.ContentType] = value;
+                if (!string.IsNullOrEmpty(value))
+                {
+                    _metadata[HttpHeaders.ContentType] = value;
+                }
             }
         }
 
@@ -123,7 +128,10 @@ namespace Aliyun.OSS
             }
             set
             {
-                _metadata[HttpHeaders.ContentEncoding] = value;
+                if (value != null)
+                {
+                    _metadata[HttpHeaders.ContentEncoding] = value;
+                }
             }
         }
 
@@ -139,7 +147,10 @@ namespace Aliyun.OSS
             }
             set
             {
-                _metadata[HttpHeaders.CacheControl] = value;
+                if (value != null)
+                {
+                    _metadata[HttpHeaders.CacheControl] = value;
+                }
             }
         }
 
@@ -155,7 +166,10 @@ namespace Aliyun.OSS
             }
             set
             {
-                _metadata[HttpHeaders.ContentDisposition] = value;
+                if (value != null)
+                {
+                    _metadata[HttpHeaders.ContentDisposition] = value;
+                }
             }
         }
 
@@ -171,7 +185,10 @@ namespace Aliyun.OSS
             }
             set
             {
-                _metadata[HttpHeaders.ETag] = value;
+                if (value != null)
+                {
+                    _metadata[HttpHeaders.ETag] = value;
+                }
             }
         }
 

--- a/sdk/Domain/ObjectMetadata.cs
+++ b/sdk/Domain/ObjectMetadata.cs
@@ -174,7 +174,7 @@ namespace Aliyun.OSS
         }
 
         /// <summary>
-        /// 获取或设置一个值表示与Object相关的hex编码的128位MD5摘要。
+        /// 获取或者设置ETAG值，如果要设置Content-Md5值，请使用Content-Md5属性。
         /// </summary>
         public string ETag
         {
@@ -188,6 +188,25 @@ namespace Aliyun.OSS
                 if (value != null)
                 {
                     _metadata[HttpHeaders.ETag] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// 获取或设置一个值表示与Object相关的hex编码的128位MD5摘要。
+        /// </summary>
+        public string ContentMd5
+        {
+            get
+            {
+                return _metadata.ContainsKey(HttpHeaders.ContentMd5)
+                    ? _metadata[HttpHeaders.ContentMd5] as string : null;
+            }
+            set
+            {
+                if (value != null)
+                {
+                    _metadata[HttpHeaders.ContentMd5] = value;
                 }
             }
         }

--- a/sdk/OssClient.cs
+++ b/sdk/OssClient.cs
@@ -56,7 +56,7 @@ namespace Aliyun.OSS
         /// <param name="accessKeySecret">STS提供的访问密钥。</param>
         /// <param name="securityToken">STS提供的安全令牌。</param>
         public OssClient(string endpoint, string accessKeyId, string accessKeySecret, string securityToken)
-            : this(new Uri(endpoint.ToLower().StartsWith("http") ? endpoint : "http://" + endpoint),
+            : this(new Uri(endpoint.ToLower().Trim().StartsWith("http") ? endpoint.Trim() : "http://" + endpoint.Trim()),
                    accessKeyId, accessKeySecret, securityToken) { }
 
         /// <summary>

--- a/sdk/OssClient.cs
+++ b/sdk/OssClient.cs
@@ -56,7 +56,7 @@ namespace Aliyun.OSS
         /// <param name="accessKeySecret">STS提供的访问密钥。</param>
         /// <param name="securityToken">STS提供的安全令牌。</param>
         public OssClient(string endpoint, string accessKeyId, string accessKeySecret, string securityToken)
-            : this(new Uri(endpoint.ToLower().Trim().StartsWith("http") ? endpoint.Trim() : "http://" + endpoint.Trim()),
+			: this(new Uri(endpoint.ToLower().Trim().StartsWith(HttpUtils.HttpProto) ? endpoint.Trim() : HttpUtils.HttpProto + endpoint.Trim()),
                    accessKeyId, accessKeySecret, securityToken) { }
 
         /// <summary>

--- a/sdk/Util/HttpUtils.cs
+++ b/sdk/Util/HttpUtils.cs
@@ -17,6 +17,7 @@ namespace Aliyun.OSS.Util
         public const string Utf8Charset = "utf-8";
         public const string Iso88591Charset = "iso-8859-1";
         public const string UrlEncodingType = "url";
+        public const string HttpProto = "http://";
         public const string DefaultContentType = "application/octet-stream";
         private const string UrlAllowedChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.~";
         private static IDictionary<string, string> _mimeDict = new Dictionary<string, string>();

--- a/sdk/aliyun-oss-sdk.csproj
+++ b/sdk/aliyun-oss-sdk.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <PropertyGroup>
-    <ProjectGuid>{67BDC800-084C-4F84-8A80-661B5AFE499A}</ProjectGuid>
+    <ProjectGuid>{EE5D6175-F4A8-4820-B657-69AA4E23ABA5}</ProjectGuid>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Library</OutputType>

--- a/sdk/aliyun-oss-sdk.csproj
+++ b/sdk/aliyun-oss-sdk.csproj
@@ -171,6 +171,7 @@
     <Compile Include="Common\Handlers\ResponseHandler.cs" />
     <Compile Include="Domain\AppendObjectRequest.cs" />
     <Compile Include="Domain\AppendObjectResult.cs" />
+    <Compile Include="Domain\ObjectMetadata.cs" />
     <Compile Include="Domain\ResumableContext.cs" />
     <Compile Include="Transform\AppendObjectResponseDeserializer.cs" />
     <Compile Include="Transform\IDeserializer.cs" />
@@ -267,7 +268,6 @@
     <Compile Include="Domain\MultipartUpload.cs" />
     <Compile Include="Domain\MultipartUploadListing.cs" />
     <Compile Include="Domain\ObjectListing.cs" />
-    <Compile Include="Domain\ObjectMetadata.cs" />
     <Compile Include="Model\UploadPartCopyRequestModel.cs" />
     <Compile Include="OssClient.cs" />
     <Compile Include="Common\OssException.cs" />

--- a/sdk/aliyun-oss-sdk.csproj
+++ b/sdk/aliyun-oss-sdk.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <PropertyGroup>
-    <ProjectGuid>{EE5D6175-F4A8-4820-B657-69AA4E23ABA5}</ProjectGuid>
+    <ProjectGuid>{67BDC800-084C-4F84-8A80-661B5AFE499A}</ProjectGuid>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Library</OutputType>
@@ -125,6 +125,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>

--- a/test/TestCase/ObjectTestCase/ObjectBasicOperationTest.cs
+++ b/test/TestCase/ObjectTestCase/ObjectBasicOperationTest.cs
@@ -1175,7 +1175,6 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
                 var oldMeta = _ossClient.GetObjectMetadata(_bucketName, key);
                 Assert.AreEqual(meta.ContentType, oldMeta.ContentType);
                 Assert.AreEqual(meta.CacheControl, oldMeta.CacheControl);
-                Assert.IsTrue(oldMeta.ExpirationTime != null);
 
                 var newMeta = new ObjectMetadata()
                 {

--- a/test/TestCase/ObjectTestCase/ObjectBasicOperationTest.cs
+++ b/test/TestCase/ObjectTestCase/ObjectBasicOperationTest.cs
@@ -1158,7 +1158,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
         /// 验证是否可以设置空值
         /// </summary>
         [Test]
-        public void ModifyObjectMetaWithUseOldMeta()
+        public void ModifyObjectMetaWithSetEmptyValue()
         {
             var key = OssTestUtils.GetObjectKey(_className);
 

--- a/test/TestCase/ObjectTestCase/ObjectBasicOperationTest.cs
+++ b/test/TestCase/ObjectTestCase/ObjectBasicOperationTest.cs
@@ -37,7 +37,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
             //create sample object
             _objectKey = OssTestUtils.GetObjectKey(_className);
             var poResult = OssTestUtils.UploadObject(_ossClient, _bucketName, _objectKey,
-                Config.UploadSampleFile, new ObjectMetadata());
+                Config.UploadTestFile, new ObjectMetadata());
             _objectETag = poResult.ETag;
 
             _event = new AutoResetEvent(false);
@@ -60,7 +60,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
             {
                 //upload the object
                 OssTestUtils.UploadObject(_ossClient, _bucketName, key,
-                    Config.UploadSampleFile, new ObjectMetadata());
+                    Config.UploadTestFile, new ObjectMetadata());
                 Assert.IsTrue(OssTestUtils.ObjectExists(_ossClient, _bucketName, key));
             }
             finally
@@ -81,7 +81,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
             {
                 //upload the object
                 OssTestUtils.UploadObject(_ossClient, _bucketName, key,
-                    Config.UploadSampleFile, null);
+                    Config.UploadTestFile, null);
                 Assert.IsTrue(OssTestUtils.ObjectExists(_ossClient, _bucketName, key));
             }
             finally
@@ -102,7 +102,35 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
             {
                 //upload the object
                 OssTestUtils.UploadObject(_ossClient, _bucketName, key,
-                    Config.UploadSampleFile);
+                    Config.UploadTestFile);
+                Assert.IsTrue(OssTestUtils.ObjectExists(_ossClient, _bucketName, key));
+            }
+            finally
+            {
+                if (OssTestUtils.ObjectExists(_ossClient, _bucketName, key))
+                {
+                    _ossClient.DeleteObject(_bucketName, key);
+                }
+            }
+        }
+
+        [Test]
+        public void UploadObjectWithMd5()
+        {
+            var key = OssTestUtils.GetObjectKey(_className);
+
+            try
+            {
+                string md5;
+                using (var fs = File.Open(Config.UploadTestFile, FileMode.Open))
+                {
+                    md5 = OssUtils.ComputeContentMd5(fs, fs.Length);
+                }
+
+                var meta = new ObjectMetadata() { ContentMd5 = md5 };
+
+                //upload the object
+                _ossClient.PutObject(_bucketName, key, Config.UploadTestFile, meta);
                 Assert.IsTrue(OssTestUtils.ObjectExists(_ossClient, _bucketName, key));
             }
             finally
@@ -128,7 +156,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
                 ContentDisposition = "abc.zip",
                 ContentEncoding = "gzip"
             };
-            var eTag = FileUtils.ComputeContentMd5(Config.UploadSampleFile);
+            var eTag = FileUtils.ComputeContentMd5(Config.UploadTestFile);
             metadata.ETag = eTag;
             //enable server side encryption
             const string encryption = "AES256";
@@ -141,7 +169,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
             {
                 //upload object
                 OssTestUtils.UploadObject(_ossClient, _bucketName, key,
-                    Config.UploadSampleFile, metadata);
+                    Config.UploadTestFile, metadata);
                 Assert.IsTrue(OssTestUtils.ObjectExists(_ossClient, _bucketName, key));
 
                 var uploadedObjectMetadata = _ossClient.GetObjectMetadata(_bucketName, key);
@@ -169,7 +197,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
 
             try
             {
-                _ossClient.PutObject(_bucketName, key, Config.UploadSampleFile, new ObjectMetadata());
+                _ossClient.PutObject(_bucketName, key, Config.UploadTestFile, new ObjectMetadata());
                 Assert.IsTrue(OssTestUtils.ObjectExists(_ossClient, _bucketName, key));
             }
             finally
@@ -188,7 +216,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
 
             try
             {
-                _ossClient.PutObject(_bucketName, key, Config.UploadSampleFile);
+                _ossClient.PutObject(_bucketName, key, Config.UploadTestFile);
                 Assert.IsTrue(OssTestUtils.ObjectExists(_ossClient, _bucketName, key));
             }
             finally
@@ -207,10 +235,10 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
 
             try
             {
-                var fileInfo = new FileInfo(Config.MultiUploadSampleFile);
+                var fileInfo = new FileInfo(Config.MultiUploadTestFile);
                 var fileSize = fileInfo.Length;
 
-                var result = _ossClient.ResumableUploadObject(_bucketName, key, Config.MultiUploadSampleFile, new ObjectMetadata(), null, fileSize + 1);
+                var result = _ossClient.ResumableUploadObject(_bucketName, key, Config.MultiUploadTestFile, new ObjectMetadata(), null, fileSize + 1);
                 Assert.IsTrue(OssTestUtils.ObjectExists(_ossClient, _bucketName, key));
                 Assert.IsTrue(result.ETag.Length > 0);
             }
@@ -230,10 +258,10 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
 
             try
             {
-                var fileInfo = new FileInfo(Config.MultiUploadSampleFile);
+                var fileInfo = new FileInfo(Config.MultiUploadTestFile);
                 var fileSize = fileInfo.Length;
 
-                var result = _ossClient.ResumableUploadObject(_bucketName, key, Config.MultiUploadSampleFile, new ObjectMetadata(), null, fileSize);
+                var result = _ossClient.ResumableUploadObject(_bucketName, key, Config.MultiUploadTestFile, new ObjectMetadata(), null, fileSize);
                 Assert.IsTrue(OssTestUtils.ObjectExists(_ossClient, _bucketName, key));
                 Assert.IsTrue(result.ETag.Length > 0);
             }
@@ -253,10 +281,10 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
 
             try
             {
-                var fileInfo = new FileInfo(Config.MultiUploadSampleFile);
+                var fileInfo = new FileInfo(Config.MultiUploadTestFile);
                 var fileSize = fileInfo.Length;
 
-                var result = _ossClient.ResumableUploadObject(_bucketName, key, Config.MultiUploadSampleFile, new ObjectMetadata(), null, fileSize - 1);
+                var result = _ossClient.ResumableUploadObject(_bucketName, key, Config.MultiUploadTestFile, new ObjectMetadata(), null, fileSize - 1);
                 Assert.IsTrue(OssTestUtils.ObjectExists(_ossClient, _bucketName, key));
                 Assert.IsTrue(result.ETag.Length > 0);
             }
@@ -276,10 +304,10 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
 
             try
             {
-                var fileInfo = new FileInfo(Config.MultiUploadSampleFile);
+                var fileInfo = new FileInfo(Config.MultiUploadTestFile);
                 var fileSize = fileInfo.Length;
 
-                var result = _ossClient.ResumableUploadObject(_bucketName, key, Config.MultiUploadSampleFile, new ObjectMetadata(), null, 1);
+                var result = _ossClient.ResumableUploadObject(_bucketName, key, Config.MultiUploadTestFile, new ObjectMetadata(), null, 1);
                 Assert.IsTrue(OssTestUtils.ObjectExists(_ossClient, _bucketName, key));
                 Assert.IsTrue(result.ETag.Length > 0);
             }
@@ -296,11 +324,11 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
         public void ResumableUploadObjectTestWithSmallObjectCheckContentType()
         {
             var key = OssTestUtils.GetObjectKey(_className);
-            var newFileName = Path.GetDirectoryName(Config.UploadSampleFile) + "/newfile.js";
+            var newFileName = Path.GetDirectoryName(Config.UploadTestFile) + "/newfile.js";
 
             try
             {
-                File.Copy(Config.UploadSampleFile, newFileName);
+                File.Copy(Config.UploadTestFile, newFileName);
 
                 var result = _ossClient.ResumableUploadObject(_bucketName, key, newFileName, new ObjectMetadata(), null);
                 Assert.IsTrue(OssTestUtils.ObjectExists(_ossClient, _bucketName, key));
@@ -323,11 +351,11 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
         public void ResumableUploadObjectTestWithBigObjectCheckContentType()
         {
             var key = OssTestUtils.GetObjectKey(_className);
-            var newFileName = Path.GetDirectoryName(Config.MultiUploadSampleFile) + "/newfile.js";
+            var newFileName = Path.GetDirectoryName(Config.MultiUploadTestFile) + "/newfile.js";
 
             try
             {
-                File.Copy(Config.MultiUploadSampleFile, newFileName, true);
+                File.Copy(Config.MultiUploadTestFile, newFileName, true);
                 var fileInfo = new FileInfo(newFileName);
                 var fileSize = fileInfo.Length;
 
@@ -360,7 +388,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
                 {
                     //try to upload the object with invalid key name
                     OssTestUtils.UploadObject(_ossClient, _bucketName, invalidKeyName,
-                        Config.UploadSampleFile, new ObjectMetadata());
+                        Config.UploadTestFile, new ObjectMetadata());
                     Assert.Fail("Upload should not pass for invalid object key name {0}", invalidKeyName);
                 }
                 catch (ArgumentException)
@@ -454,7 +482,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
             {
                 //upload the object
                 OssTestUtils.UploadObject(_ossClient, _bucketName, key,
-                    Config.UploadSampleFile, new ObjectMetadata());
+                    Config.UploadTestFile, new ObjectMetadata());
 
                 //list objects by specifying bucket name
                 var allObjects = _ossClient.ListObjects(_bucketName);
@@ -630,7 +658,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
             var key = OssTestUtils.GetObjectKey(_className) + "";
             try
             {
-                using (var fs = File.Open(Config.UploadSampleFile, FileMode.Open))
+                using (var fs = File.Open(Config.UploadTestFile, FileMode.Open))
                 {
                     _ossClient.PutObject(_bucketName, key, fs, null);
                 }
@@ -660,7 +688,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
             var key = OssTestUtils.GetObjectKey(_className) + ".js";
             try
             {
-                using (var fs = File.Open(Config.UploadSampleFile, FileMode.Open))
+                using (var fs = File.Open(Config.UploadTestFile, FileMode.Open))
                 {
                     _ossClient.PutObject(_bucketName, key, fs, null);
                 }
@@ -689,7 +717,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
                 var metadata = new ObjectMetadata();
                 metadata.ContentType = "application/vnd.android.package-archive";
 
-                using (var fs = File.Open(Config.UploadSampleFile, FileMode.Open))
+                using (var fs = File.Open(Config.UploadTestFile, FileMode.Open))
                 {
                     _ossClient.PutObject(_bucketName, key, fs, metadata);
                 }
@@ -714,10 +742,10 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
         public void UploadObjectWithKeySurfix()
         {
             var key = OssTestUtils.GetObjectKey(_className) + ".js";
-            var newFileName = Path.GetDirectoryName(Config.UploadSampleFile) + "/newfile";
+            var newFileName = Path.GetDirectoryName(Config.UploadTestFile) + "/newfile";
             try
             {
-                File.Copy(Config.UploadSampleFile, newFileName, true);
+                File.Copy(Config.UploadTestFile, newFileName, true);
                 OssTestUtils.UploadObject(_ossClient, _bucketName, key, newFileName, null);
                 Assert.IsTrue(OssTestUtils.ObjectExists(_ossClient, _bucketName, key));
 
@@ -739,11 +767,11 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
         public void UploadObjectWithFileSurfix()
         {
             var key = OssTestUtils.GetObjectKey(_className);
-            var newFileName = Path.GetDirectoryName(Config.UploadSampleFile) + "/newfile.js";
+            var newFileName = Path.GetDirectoryName(Config.UploadTestFile) + "/newfile.js";
 
             try
             {
-                File.Copy(Config.UploadSampleFile, newFileName, true);
+                File.Copy(Config.UploadTestFile, newFileName, true);
                 OssTestUtils.UploadObject(_ossClient, _bucketName, key, newFileName, null);
                 Assert.IsTrue(OssTestUtils.ObjectExists(_ossClient, _bucketName, key));
 
@@ -765,11 +793,11 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
         public void UploadObjectWithFileSurfix2()
         {
             var key = OssTestUtils.GetObjectKey(_className);
-            var newFileName = Path.GetDirectoryName(Config.UploadSampleFile) + "/newfile.m4u";
+            var newFileName = Path.GetDirectoryName(Config.UploadTestFile) + "/newfile.m4u";
 
             try
             {
-                File.Copy(Config.UploadSampleFile, newFileName, true);
+                File.Copy(Config.UploadTestFile, newFileName, true);
                 OssTestUtils.UploadObject(_ossClient, _bucketName, key, newFileName, null);
                 Assert.IsTrue(OssTestUtils.ObjectExists(_ossClient, _bucketName, key));
 
@@ -791,11 +819,11 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
         public void UploadObjectWithFileSurfixAndFileSurfix()
         {
             var key = OssTestUtils.GetObjectKey(_className) + ".potx";
-            var newFileName = Path.GetDirectoryName(Config.UploadSampleFile) + "/newFile.docx";
+            var newFileName = Path.GetDirectoryName(Config.UploadTestFile) + "/newFile.docx";
 
             try
             {
-                File.Copy(Config.UploadSampleFile, newFileName, true);
+                File.Copy(Config.UploadTestFile, newFileName, true);
                 OssTestUtils.UploadObject(_ossClient, _bucketName, key, newFileName, null);
                 Assert.IsTrue(OssTestUtils.ObjectExists(_ossClient, _bucketName, key));
 
@@ -878,7 +906,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
             {
                 try
                 {
-                    _ossClient.PutObject(bucketName, key, Config.UploadSampleFile);
+                    _ossClient.PutObject(bucketName, key, Config.UploadTestFile);
                 }
                 catch (Exception)
                 {
@@ -917,7 +945,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
                     ContentType = "text/rtf"
                 };
 
-                _ossClient.PutObject(_bucketName, key, Config.UploadSampleFile, meta);
+                _ossClient.PutObject(_bucketName, key, Config.UploadTestFile, meta);
                 Assert.IsTrue(OssTestUtils.ObjectExists(_ossClient, _bucketName, key));
 
                 var oldMeta = _ossClient.GetObjectMetadata(_bucketName, key);
@@ -953,7 +981,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
                     ContentType = "text/rtf"
                 };
 
-                _ossClient.PutObject(_bucketName, key, Config.UploadSampleFile, meta);
+                _ossClient.PutObject(_bucketName, key, Config.UploadTestFile, meta);
                 Assert.IsTrue(OssTestUtils.ObjectExists(_ossClient, _bucketName, key));
 
                 var oldMeta = _ossClient.GetObjectMetadata(_bucketName, key);
@@ -989,7 +1017,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
                     CacheControl = "public"
                 };
 
-                _ossClient.PutObject(_bucketName, key, Config.UploadSampleFile, meta);
+                _ossClient.PutObject(_bucketName, key, Config.UploadTestFile, meta);
                 Assert.IsTrue(OssTestUtils.ObjectExists(_ossClient, _bucketName, key));
 
                 var oldMeta = _ossClient.GetObjectMetadata(_bucketName, key);
@@ -1026,7 +1054,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
                     ContentType = "text/rtf",
                 };
 
-                _ossClient.PutObject(_bucketName, key, Config.UploadSampleFile, meta);
+                _ossClient.PutObject(_bucketName, key, Config.UploadTestFile, meta);
                 Assert.IsTrue(OssTestUtils.ObjectExists(_ossClient, _bucketName, key));
 
                 var oldMeta = _ossClient.GetObjectMetadata(_bucketName, key);
@@ -1068,7 +1096,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
                     ContentType = "text/rtf",
                 };
 
-                _ossClient.PutObject(_bucketName, key, Config.UploadSampleFile, meta);
+                _ossClient.PutObject(_bucketName, key, Config.UploadTestFile, meta);
                 Assert.IsTrue(OssTestUtils.ObjectExists(_ossClient, _bucketName, key));
 
                 var oldMeta = _ossClient.GetObjectMetadata(_bucketName, key);
@@ -1097,11 +1125,11 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
         public void ModifyObjectMetaWithAddMeta() 
         {
             var key = OssTestUtils.GetObjectKey(_className);
-            var newFileName = Path.GetDirectoryName(Config.UploadSampleFile) + "/newfile";
+            var newFileName = Path.GetDirectoryName(Config.UploadTestFile) + "/newfile";
 
             try
             {
-                File.Copy(Config.UploadSampleFile, newFileName, true);
+                File.Copy(Config.UploadTestFile, newFileName, true);
 
                 _ossClient.PutObject(_bucketName, key, newFileName, new ObjectMetadata());
                 Assert.IsTrue(OssTestUtils.ObjectExists(_ossClient, _bucketName, key));
@@ -1141,7 +1169,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
                     ContentType = "text/rtf",
                 };
 
-                _ossClient.PutObject(_bucketName, key, Config.UploadSampleFile, meta);
+                _ossClient.PutObject(_bucketName, key, Config.UploadTestFile, meta);
                 Assert.IsTrue(OssTestUtils.ObjectExists(_ossClient, _bucketName, key));
 
                 var oldMeta = _ossClient.GetObjectMetadata(_bucketName, key);
@@ -1184,7 +1212,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
             try
             {
                 long position = 0;
-                using (var fs = File.Open(Config.UploadSampleFile, FileMode.Open))
+                using (var fs = File.Open(Config.UploadTestFile, FileMode.Open))
                 {
                     var fileLength = fs.Length;
                     var request = new AppendObjectRequest(_bucketName, key)
@@ -1199,7 +1227,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
                     position = result.NextAppendPosition;
                 }
 
-                using (var fs = File.Open(Config.UploadSampleFile, FileMode.Open))
+                using (var fs = File.Open(Config.UploadTestFile, FileMode.Open))
                 {
                     var fileLength = fs.Length;
                     var request = new AppendObjectRequest(_bucketName, key)
@@ -1235,7 +1263,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
             try
             {
                 long position = 0;
-                using (var fs = File.Open(Config.UploadSampleFile, FileMode.Open))
+                using (var fs = File.Open(Config.UploadTestFile, FileMode.Open))
                 {
                     var fileLength = fs.Length;
                     var request = new AppendObjectRequest(_bucketName, key)
@@ -1251,7 +1279,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
                     position = result.NextAppendPosition;
                 }
 
-                using (var fs = File.Open(Config.UploadSampleFile, FileMode.Open))
+                using (var fs = File.Open(Config.UploadTestFile, FileMode.Open))
                 {
                     var fileLength = fs.Length;
                     var request = new AppendObjectRequest(_bucketName, key)
@@ -1285,7 +1313,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
 
             try
             {
-                using (var fs = File.Open(Config.UploadSampleFile, FileMode.Open))
+                using (var fs = File.Open(Config.UploadTestFile, FileMode.Open))
                 {
                     var request = new AppendObjectRequest(_bucketName, key)
                     {
@@ -1327,7 +1355,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
 
             try
             {
-                using (var fs = File.Open(Config.UploadSampleFile, FileMode.Open))
+                using (var fs = File.Open(Config.UploadTestFile, FileMode.Open))
                 {
                     var fileLength = fs.Length;
                     var request = new AppendObjectRequest(_bucketName, key)
@@ -1366,9 +1394,9 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
 
             try
             {
-                _ossClient.PutObject(_bucketName, key, Config.UploadSampleFile);
+                _ossClient.PutObject(_bucketName, key, Config.UploadTestFile);
 
-                using (var fs = File.Open(Config.UploadSampleFile, FileMode.Open))
+                using (var fs = File.Open(Config.UploadTestFile, FileMode.Open))
                 {
                     var request = new AppendObjectRequest(_bucketName, key)
                     {
@@ -1411,7 +1439,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
             try
             {
                 long position = 0;
-                using (var fs = File.Open(Config.UploadSampleFile, FileMode.Open))
+                using (var fs = File.Open(Config.UploadTestFile, FileMode.Open))
                 {
                     var fileLength = fs.Length;
                     var request = new AppendObjectRequest(_bucketName, key)
@@ -1426,7 +1454,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
                     position = result.NextAppendPosition;
                 }
 
-                using (var fs = File.Open(Config.UploadSampleFile, FileMode.Open))
+                using (var fs = File.Open(Config.UploadTestFile, FileMode.Open))
                 {
                     var fileLength = fs.Length;
                      var request = new AppendObjectRequest(_bucketName, key)
@@ -1457,7 +1485,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
 
             try
             {
-                using (var fs = File.Open(Config.UploadSampleFile, FileMode.Open))
+                using (var fs = File.Open(Config.UploadTestFile, FileMode.Open))
                 {
                     var request = new AppendObjectRequest(_bucketName, _objectKey)
                     {
@@ -1487,7 +1515,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
 
             try
             {
-                using (var fs = File.Open(Config.UploadSampleFile, FileMode.Open))
+                using (var fs = File.Open(Config.UploadTestFile, FileMode.Open))
                 {
                     var fileLength = fs.Length;
                     var request = new AppendObjectRequest(_bucketName, key)
@@ -1501,7 +1529,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
                     Assert.AreEqual(fileLength, result.NextAppendPosition);
                 }
 
-                _ossClient.PutObject(_bucketName, key, Config.UploadSampleFile);
+                _ossClient.PutObject(_bucketName, key, Config.UploadTestFile);
             }
             finally
             {
@@ -1523,7 +1551,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
 
             try
             {
-                var result = _ossClient.ResumableUploadObject(_bucketName, key, Config.MultiUploadSampleFile, null,
+                var result = _ossClient.ResumableUploadObject(_bucketName, key, Config.MultiUploadTestFile, null,
                                                            Config.DownloadFolder);
                 Assert.IsTrue(OssTestUtils.ObjectExists(_ossClient, _bucketName, key));
                 Assert.IsTrue(result.ETag.Length > 0);
@@ -1571,7 +1599,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
                 client.beginFailedIndex = 2;
                 client.endFailedIndex = 3;
 
-                var result = client.ResumableUploadObject(_bucketName, key, Config.MultiUploadSampleFile, null,
+                var result = client.ResumableUploadObject(_bucketName, key, Config.MultiUploadTestFile, null,
                                                         Config.DownloadFolder);
                 Assert.IsTrue(OssTestUtils.ObjectExists(_ossClient, _bucketName, key));
                 Assert.IsTrue(result.ETag.Length > 0);
@@ -1597,7 +1625,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
                 client.endFailedIndex = 100;
                 client.currentIndex = 0;
 
-                var result = client.ResumableUploadObject(_bucketName, key, Config.MultiUploadSampleFile, null,
+                var result = client.ResumableUploadObject(_bucketName, key, Config.MultiUploadTestFile, null,
                                                         Config.DownloadFolder);
                 Assert.IsFalse(true);
             }
@@ -1625,7 +1653,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
                 client.beginFailedIndex = 2;
                 client.endFailedIndex = 100;
 
-                var result = client.ResumableUploadObject(_bucketName, key, Config.MultiUploadSampleFile, null,
+                var result = client.ResumableUploadObject(_bucketName, key, Config.MultiUploadTestFile, null,
                                                        Config.DownloadFolder);
                 Assert.IsTrue(false);
             }
@@ -1640,7 +1668,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
                 client.endFailedIndex = 0;
                 client.currentIndex = 1;
 
-                var result = client.ResumableUploadObject(_bucketName, key, Config.MultiUploadSampleFile, null,
+                var result = client.ResumableUploadObject(_bucketName, key, Config.MultiUploadTestFile, null,
                                                        Config.DownloadFolder);
                 Assert.IsTrue(OssTestUtils.ObjectExists(_ossClient, _bucketName, key));
                 Assert.IsTrue(result.ETag.Length > 0);
@@ -1664,7 +1692,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
             {
                 var objectKey = OssTestUtils.GetObjectKey(_className);
                 OssTestUtils.UploadObject(_ossClient, _bucketName, objectKey,
-                    Config.UploadSampleFile, new ObjectMetadata());
+                    Config.UploadTestFile, new ObjectMetadata());
                 sampleObjects.Add(objectKey);
                 System.Threading.Thread.Sleep(100);
             }

--- a/test/TestCase/ObjectTestCase/ObjectBasicOperationTest.cs
+++ b/test/TestCase/ObjectTestCase/ObjectBasicOperationTest.cs
@@ -1624,7 +1624,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
                 client.endFailedIndex = 100;
                 client.currentIndex = 0;
 
-                var result = client.ResumableUploadObject(_bucketName, key, Config.MultiUploadTestFile, null,
+                client.ResumableUploadObject(_bucketName, key, Config.MultiUploadTestFile, null,
                                                         Config.DownloadFolder);
                 Assert.IsFalse(true);
             }
@@ -1652,7 +1652,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
                 client.beginFailedIndex = 2;
                 client.endFailedIndex = 100;
 
-                var result = client.ResumableUploadObject(_bucketName, key, Config.MultiUploadTestFile, null,
+                client.ResumableUploadObject(_bucketName, key, Config.MultiUploadTestFile, null,
                                                        Config.DownloadFolder);
                 Assert.IsTrue(false);
             }

--- a/test/TestCase/ObjectTestCase/ObjectBasicOperationTest.cs
+++ b/test/TestCase/ObjectTestCase/ObjectBasicOperationTest.cs
@@ -1126,6 +1126,52 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
             }
         }
 
+        /// <summary>
+        /// 验证是否可以设置空值
+        /// </summary>
+        [Test]
+        public void ModifyObjectMetaWithUseOldMeta()
+        {
+            var key = OssTestUtils.GetObjectKey(_className);
+
+            try
+            {
+                var meta = new ObjectMetadata()
+                {
+                    ContentType = "text/rtf",
+                };
+
+                _ossClient.PutObject(_bucketName, key, Config.UploadSampleFile, meta);
+                Assert.IsTrue(OssTestUtils.ObjectExists(_ossClient, _bucketName, key));
+
+                var oldMeta = _ossClient.GetObjectMetadata(_bucketName, key);
+                Assert.AreEqual(meta.ContentType, oldMeta.ContentType);
+                Assert.AreEqual(meta.CacheControl, oldMeta.CacheControl);
+                Assert.IsTrue(oldMeta.ExpirationTime != null);
+
+                var newMeta = new ObjectMetadata()
+                {
+                    CacheControl = "",
+                    ContentEncoding = null,
+                    ContentType = "application/octet-stream",
+                    ExpirationTime = oldMeta.ExpirationTime
+                };
+
+                _ossClient.ModifyObjectMeta(_bucketName, key, newMeta);
+
+                var newMeta2 = _ossClient.GetObjectMetadata(_bucketName, key);
+                Assert.AreEqual("application/octet-stream", newMeta2.ContentType);
+                Assert.AreEqual(null, newMeta2.CacheControl);
+            }
+            finally
+            {
+                if (OssTestUtils.ObjectExists(_ossClient, _bucketName, key))
+                {
+                    _ossClient.DeleteObject(_bucketName, key);
+                }
+            }
+        }
+
         #endregion
 
         #region append object

--- a/test/TestCase/ObjectTestCase/ObjectCopyTest.cs
+++ b/test/TestCase/ObjectTestCase/ObjectCopyTest.cs
@@ -109,8 +109,6 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
         [Test]
         public void CopyObjectBasicTestWithInvalidObject()
         {
-            var targetObjectKey = OssTestUtils.GetObjectKey(_className);
-
             //construct metadata
             var metadata = new ObjectMetadata();
             const string userMetaKey = "myKey";

--- a/test/TestCase/ObjectTestCase/ObjectCopyTest.cs
+++ b/test/TestCase/ObjectTestCase/ObjectCopyTest.cs
@@ -34,14 +34,14 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
             _sourceObjectKey = OssTestUtils.GetObjectKey(_className);
             var metadata = new ObjectMetadata();
             var poResult = OssTestUtils.UploadObject(_ossClient, _bucketName, _sourceObjectKey, 
-                Config.UploadSampleFile, metadata);
+                Config.UploadTestFile, metadata);
             _sourceObjectETag = poResult.ETag;
 
             //upload multipart sample object as source object
             _sourceBigObjectKey = _sourceObjectKey + ".js";
             metadata = new ObjectMetadata();
             poResult = OssTestUtils.UploadObject(_ossClient, _bucketName, _sourceBigObjectKey,
-                Config.MultiUploadSampleFile, metadata);
+                Config.MultiUploadTestFile, metadata);
             _sourceBigObjectETag = poResult.ETag;
         }
 

--- a/test/TestCase/ObjectTestCase/ObjectCopyTest.cs
+++ b/test/TestCase/ObjectTestCase/ObjectCopyTest.cs
@@ -78,6 +78,64 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
         }
 
         [Test]
+        public void CopyObjectBasicTestWithInvalidBucket()
+        {
+            var targetObjectKey = OssTestUtils.GetObjectKey(_className);
+
+            //construct metadata
+            var metadata = new ObjectMetadata();
+            const string userMetaKey = "myKey";
+            const string userMetaValue = "myValue";
+            metadata.UserMetadata.Add(userMetaKey, userMetaValue);
+            metadata.CacheControl = "No-Cache";
+
+            try
+            {
+                var coRequest = new CopyObjectRequest(_bucketName, _sourceObjectKey, "/invalid_bucket", targetObjectKey)
+                {
+                    NewObjectMetadata = metadata
+                };
+
+                _ossClient.CopyObject(coRequest);
+
+                Assert.Fail("Copy object should not pass with invalid bucket name");
+            }
+            catch (ArgumentException)
+            {
+                Assert.IsTrue(true);
+            } 
+        }
+
+        [Test]
+        public void CopyObjectBasicTestWithInvalidObject()
+        {
+            var targetObjectKey = OssTestUtils.GetObjectKey(_className);
+
+            //construct metadata
+            var metadata = new ObjectMetadata();
+            const string userMetaKey = "myKey";
+            const string userMetaValue = "myValue";
+            metadata.UserMetadata.Add(userMetaKey, userMetaValue);
+            metadata.CacheControl = "No-Cache";
+
+            try
+            {
+                var coRequest = new CopyObjectRequest(_bucketName, _sourceObjectKey, _bucketName, "/__%")
+                {
+                    NewObjectMetadata = metadata
+                };
+
+                _ossClient.CopyObject(coRequest);
+
+                Assert.Fail("Copy object should not pass with invalid object name");
+            }
+            catch (ArgumentException)
+            {
+                Assert.IsTrue(true);
+            } 
+        }
+
+        [Test]
         public void CopyObjectMatchingETagPositiveTest()
         {
             var targetObjectKey = OssTestUtils.GetObjectKey(_className);

--- a/test/TestCase/ObjectTestCase/ObjectEncodingTypeTest.cs
+++ b/test/TestCase/ObjectTestCase/ObjectEncodingTypeTest.cs
@@ -51,7 +51,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
 
             try
             {
-                _ossClient.PutObject(_bucketName, newKey, Config.UploadSampleFile);
+                _ossClient.PutObject(_bucketName, newKey, Config.UploadTestFile);
 
                 Assert.IsTrue(OssTestUtils.ObjectExists(_ossClient, _bucketName, newKey));
 
@@ -78,9 +78,9 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
 
             try
             {
-                _ossClient.PutObject(_bucketName, newKey1, Config.UploadSampleFile);
-                _ossClient.PutObject(_bucketName, newKey2, Config.UploadSampleFile);
-                _ossClient.PutObject(_bucketName, newKey3, Config.UploadSampleFile);
+                _ossClient.PutObject(_bucketName, newKey1, Config.UploadTestFile);
+                _ossClient.PutObject(_bucketName, newKey2, Config.UploadTestFile);
+                _ossClient.PutObject(_bucketName, newKey3, Config.UploadTestFile);
 
                 Assert.IsTrue(OssTestUtils.ObjectExists(_ossClient, _bucketName, newKey1));
                 Assert.IsTrue(OssTestUtils.ObjectExists(_ossClient, _bucketName, newKey2));
@@ -124,7 +124,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
                 // 设置每块为 5M
                 const int partSize = 5 * 1024 * 1024;
 
-                var fileInfo = new FileInfo(Config.MultiUploadSampleFile);
+                var fileInfo = new FileInfo(Config.MultiUploadTestFile);
 
                 // 计算分块数目
                 var partCount = OssTestUtils.CalculatePartCount(fileInfo.Length, partSize);
@@ -190,7 +190,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
             {
                 var objectKey = OssTestUtils.GetObjectKey(_className);
                 OssTestUtils.UploadObject(_ossClient, _bucketName, objectKey,
-                    Config.UploadSampleFile, new ObjectMetadata());
+                    Config.UploadTestFile, new ObjectMetadata());
                 sampleObjects.Add(objectKey);
                 System.Threading.Thread.Sleep(100);
             }

--- a/test/TestCase/ObjectTestCase/ObjectMultipartUploadTest.cs
+++ b/test/TestCase/ObjectTestCase/ObjectMultipartUploadTest.cs
@@ -33,7 +33,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
             _sourceObjectKey = OssTestUtils.GetObjectKey(_className);
             var metadata = new ObjectMetadata();
             var poResult = OssTestUtils.UploadObject(_ossClient, _bucketName, _sourceObjectKey,
-                Config.UploadSampleFile, metadata);
+                Config.UploadTestFile, metadata);
             _objectETag = poResult.ETag;
         }
 
@@ -46,7 +46,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
         [Test]
         public void MultipartUploadComplexStepTest()
         {
-            var sourceFile = Config.MultiUploadSampleFile;
+            var sourceFile = Config.MultiUploadTestFile;
             //get target object name
             var targetObjectKey = OssTestUtils.GetObjectKey(_className);
 
@@ -120,7 +120,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
         [Test]
         public void MultipartUploadAbortInMiddleTest()
         {
-            var sourceFile = Config.MultiUploadSampleFile;
+            var sourceFile = Config.MultiUploadTestFile;
             //get target object name
             var targetObjectKey = OssTestUtils.GetObjectKey(_className);
 

--- a/test/TestCase/ObjectTestCase/ObjectSignedUriTest.cs
+++ b/test/TestCase/ObjectTestCase/ObjectSignedUriTest.cs
@@ -32,7 +32,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
             //create sample object
             _objectKey = OssTestUtils.GetObjectKey(_className);
             var poResult = OssTestUtils.UploadObject(_ossClient, _bucketName, _objectKey,
-                Config.UploadSampleFile, new ObjectMetadata());
+                Config.UploadTestFile, new ObjectMetadata());
             _objectETag = poResult.ETag;
         }
 

--- a/test/Util/Config.cs
+++ b/test/Util/Config.cs
@@ -12,8 +12,8 @@ namespace Aliyun.OSS.Test.Util
 		public static readonly string DisabledAccessKeyId = ConfigurationManager.AppSettings["DisabledAccessKeyId"];
 		public static readonly string DisabledAccessKeySecret = ConfigurationManager.AppSettings["DisabledAccessKeySecret"];
 		public static readonly string SecondEndpoint = ConfigurationManager.AppSettings["SecondEndpoint"];
-		public static readonly string UploadSampleFile = ConfigurationManager.AppSettings["UploadSampleFile"];
-		public static readonly string MultiUploadSampleFile = ConfigurationManager.AppSettings["MultiUploadSampleFile"];
+		public static readonly string UploadTestFile = ConfigurationManager.AppSettings["UploadTestFile"];
+		public static readonly string MultiUploadTestFile = ConfigurationManager.AppSettings["MultiUploadTestFile"];
 		public static readonly string DownloadFolder = ConfigurationManager.AppSettings["DownloadFolder"];
     }
 }

--- a/test/aliyun-oss-sdk-test.csproj
+++ b/test/aliyun-oss-sdk-test.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{AFDCA7E3-F277-4DF8-BD16-227F235935A7}</ProjectGuid>
+    <ProjectGuid>{597D1FDD-CC1D-41CB-B914-A9F60486D9DC}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Aliyun.OSS.Test</RootNamespace>
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -28,6 +29,7 @@
     <OutputPath>bin\Release\</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject />

--- a/test/aliyun-oss-sdk-test.csproj
+++ b/test/aliyun-oss-sdk-test.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{597D1FDD-CC1D-41CB-B914-A9F60486D9DC}</ProjectGuid>
+    <ProjectGuid>{AFDCA7E3-F277-4DF8-BD16-227F235935A7}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Aliyun.OSS.Test</RootNamespace>
@@ -28,6 +28,9 @@
     <OutputPath>bin\Release\</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/test/app.config
+++ b/test/app.config
@@ -7,9 +7,9 @@
     <add key="ProxyHost" value=""/>
     <add key="ProxyPort" value=""/>
     <add key="DisabledAccessKeyId" value="DisabledAccessKeyId"/>
-    <add key="UploadSampleFile" value="path to upload sample file>"/>
+    <add key="UploadTestFile" value="path to upload test file"/>
     <add key="DownloadFolder" value="path to download folder"/>
-    <add key="MultiUploadSampleFile" value="path to multi upload sample file"/>
+    <add key="MultiUploadTestFile" value="path to multi upload test file"/>
     <add key="DisabledAccessKeySecret" value="DisabledAccessKeySecret"/>
     <add key="SecondEndpoint" value="http://oss-cn-hangzhou.aliyuncs.com"/>
   </appSettings>


### PR DESCRIPTION
1，trim 参数。
2，去除无用的变量
3，copy文件时检查目标bucket和object的合法性
4，ObjectMetadata增加Content-Md5属性
5，修改测试的配置项名称（sample->test）
6，用户可以设置ObjectMetadata的属性为null，此时sdk会忽略，不会报错。