### PR TITLE
Create Bucket with IA/Archive support and add restore API

### DIFF
--- a/samples/Samples/RestoreArchiveObjectSample.cs
+++ b/samples/Samples/RestoreArchiveObjectSample.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Net;
+using System.Threading;
+using Aliyun.OSS.Model;
+using Aliyun.OSS.Common;
+namespace Aliyun.OSS.Samples
+{
+    /// <summary>
+    /// Sample usage of RestoreObject API
+    /// </summary>
+    public static class RestoreArchiveObjectSample
+    {
+        static string accessKeyId = Config.AccessKeyId;
+        static string accessKeySecret = Config.AccessKeySecret;
+        static string endpoint = Config.Endpoint;
+        static OssClient client = new OssClient(endpoint, accessKeyId, accessKeySecret);
+
+        public static void RestoreArchiveObject(string bucketName, string key, bool waitUtilFinished = true, int maxWaitTimeInSeconds = 600)
+        {
+            RestoreObjectResult result = client.RestoreObject(bucketName, key);
+            if (result.HttpStatusCode != HttpStatusCode.Accepted || !waitUtilFinished)
+            {
+                throw new OssException(result.RequestId + ", " + result.HttpStatusCode + " ,");
+            }
+
+            while (maxWaitTimeInSeconds > 0)
+            {
+                var meta = client.GetObjectMetadata(bucketName, key);
+                string restoreStatus = meta.HttpMetadata["x-oss-restore"] as string;
+                if (restoreStatus != null && restoreStatus.StartsWith("ongoing-request=\"false\"", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    break;
+                }
+
+                Thread.Sleep(1000);
+                maxWaitTimeInSeconds--;
+            }
+
+            if (maxWaitTimeInSeconds == 0)
+            {
+                throw new TimeoutException();
+            }
+        }
+
+    }
+}

--- a/samples/aliyun-oss-sdk-samples.csproj
+++ b/samples/aliyun-oss-sdk-samples.csproj
@@ -12,7 +12,6 @@
     </TargetFrameworkProfile>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <SignAssembly>False</SignAssembly>
-    <DelaySign>False</DelaySign>
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
     <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
     <NoStdLib>False</NoStdLib>
@@ -125,6 +124,7 @@
     <Compile Include="Samples\SetBucketAclSample.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Samples\RestoreArchiveObjectSample.cs" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/sdk/Commands/CreateBucketCommand.cs
+++ b/sdk/Commands/CreateBucketCommand.cs
@@ -5,7 +5,9 @@
  */
 
 using System;
+using System.IO;
 using Aliyun.OSS.Common.Communication;
+using Aliyun.OSS.Transform;
 using Aliyun.OSS.Util;
 
 namespace Aliyun.OSS.Commands
@@ -24,19 +26,35 @@ namespace Aliyun.OSS.Commands
             get { return _bucketName; }
         }
 
+        protected override Stream Content
+        {
+            get
+            {
+                return SerializerFactory.GetFactory().CreateCreateBucketSerialization()
+                                        .Serialize(StorageClass);
+            }
+        }
+
+        protected StorageClass StorageClass
+        {
+            get;
+            set;
+        }
+
         private CreateBucketCommand(IServiceClient client, Uri endpoint, ExecutionContext context,
-                                    string bucketName)
+                                    string bucketName, StorageClass storageClass)
             : base(client, endpoint, context)
         {
             OssUtils.CheckBucketName(bucketName);
             _bucketName = bucketName;
+            StorageClass = storageClass;
         }
 
         public static CreateBucketCommand Create(IServiceClient client, Uri endpoint,
                                                  ExecutionContext context,
-                                                 string bucketName)
+                                                 string bucketName, StorageClass storageClass = StorageClass.Standard)
         {
-            return new CreateBucketCommand(client, endpoint, context, bucketName);
+            return new CreateBucketCommand(client, endpoint, context, bucketName, storageClass);
         }
     }
 }

--- a/sdk/Commands/CreateBucketCommand.cs
+++ b/sdk/Commands/CreateBucketCommand.cs
@@ -30,7 +30,8 @@ namespace Aliyun.OSS.Commands
         {
             get
             {
-                return SerializerFactory.GetFactory().CreateCreateBucketSerialization()
+
+                return StorageClass == StorageClass.Standard ? null : SerializerFactory.GetFactory().CreateCreateBucketSerialization()
                                         .Serialize(StorageClass);
             }
         }

--- a/sdk/Commands/CreateBucketCommand.cs
+++ b/sdk/Commands/CreateBucketCommand.cs
@@ -30,20 +30,19 @@ namespace Aliyun.OSS.Commands
         {
             get
             {
-
-                return StorageClass == StorageClass.Standard ? null : SerializerFactory.GetFactory().CreateCreateBucketSerialization()
-                                        .Serialize(StorageClass);
+                return StorageClass == null ? null : SerializerFactory.GetFactory().CreateCreateBucketSerialization()
+                                        .Serialize(StorageClass.Value);
             }
         }
 
-        protected StorageClass StorageClass
+        protected StorageClass? StorageClass
         {
             get;
             set;
         }
 
         private CreateBucketCommand(IServiceClient client, Uri endpoint, ExecutionContext context,
-                                    string bucketName, StorageClass storageClass)
+                                    string bucketName, StorageClass? storageClass)
             : base(client, endpoint, context)
         {
             OssUtils.CheckBucketName(bucketName);
@@ -53,7 +52,7 @@ namespace Aliyun.OSS.Commands
 
         public static CreateBucketCommand Create(IServiceClient client, Uri endpoint,
                                                  ExecutionContext context,
-                                                 string bucketName, StorageClass storageClass = StorageClass.Standard)
+                                                 string bucketName, StorageClass? storageClass = null)
         {
             return new CreateBucketCommand(client, endpoint, context, bucketName, storageClass);
         }

--- a/sdk/Commands/OssCommand.cs
+++ b/sdk/Commands/OssCommand.cs
@@ -57,6 +57,12 @@ namespace Aliyun.OSS.Commands
             get { return null; }
         }
 
+        protected bool UseChunkedEncoding
+        {
+            get;
+            private set;
+        }
+
         protected bool ParametersInUri
         {
             get;
@@ -98,6 +104,7 @@ namespace Aliyun.OSS.Commands
                 Method = Method,
                 Endpoint = OssUtils.MakeBucketEndpoint(Endpoint, Bucket, conf),
                 ResourcePath = OssUtils.MakeResourcePath(Endpoint, Bucket, Key),
+                UseChunkedEncoding = UseChunkedEncoding,
                 ParametersInUri = ParametersInUri
             };
 

--- a/sdk/Commands/OssCommand.cs
+++ b/sdk/Commands/OssCommand.cs
@@ -57,6 +57,12 @@ namespace Aliyun.OSS.Commands
             get { return null; }
         }
 
+        protected bool ParametersInUri
+        {
+            get;
+            set;
+        }
+
         protected OssCommand(IServiceClient client, Uri endpoint, ExecutionContext context)
         {
             Client = client;
@@ -91,7 +97,8 @@ namespace Aliyun.OSS.Commands
             {
                 Method = Method,
                 Endpoint = OssUtils.MakeBucketEndpoint(Endpoint, Bucket, conf),
-                ResourcePath = OssUtils.MakeResourcePath(Endpoint, Bucket, Key)
+                ResourcePath = OssUtils.MakeResourcePath(Endpoint, Bucket, Key),
+                ParametersInUri = ParametersInUri
             };
 
             foreach (var p in Parameters) 

--- a/sdk/Commands/RestoreObjectCommand.cs
+++ b/sdk/Commands/RestoreObjectCommand.cs
@@ -1,0 +1,70 @@
+﻿/*
+ * Copyright (C) Alibaba Cloud Computing
+ * All rights reserved.
+ * 
+ */
+
+using System;
+using System.Collections.Generic;
+using Aliyun.OSS.Common.Communication;
+using Aliyun.OSS.Util;
+using Aliyun.OSS.Transform;
+using Aliyun.OSS.Properties;
+using Aliyun.OSS.Model;
+
+namespace Aliyun.OSS.Commands
+{
+    internal class RestoreObjectCommand : OssCommand<RestoreObjectResult>
+    {
+        private string bucketName;
+        private string key;
+
+        protected override string Bucket
+        {
+            get { 
+                return bucketName; 
+            }
+        }
+
+        protected override string Key
+        {
+            get {
+                return key; 
+            }
+        }
+
+        protected override HttpMethod Method
+        {
+            get { return HttpMethod.Post; }
+        }
+
+        protected override IDictionary<string, string> Parameters
+        {
+            get
+            {
+                var parameters = new Dictionary<string, string>();
+                parameters[RequestParameters.SUBRESOURCE_RESTORE] = null;
+                return parameters;
+            }
+        }
+
+        private RestoreObjectCommand(IServiceClient client, Uri endpoint, ExecutionContext context,
+                                     string bucketName, string key, IDeserializer<ServiceResponse, RestoreObjectResult> deserializer)
+            : base(client, endpoint, context, deserializer)
+        {
+            OssUtils.CheckBucketName(bucketName);
+            OssUtils.CheckObjectKey(key);
+
+            this.bucketName = bucketName;
+            this.key = key;
+            this.ParametersInUri = true; // in restore request, the parameter restore needs to be in uri
+        }
+
+        public static RestoreObjectCommand Create(IServiceClient client, Uri endpoint,
+                                                 ExecutionContext context,
+                                                 string bucketName, string key)
+        {
+            return new RestoreObjectCommand(client, endpoint, context, bucketName, key, DeserializerFactory.GetFactory().CreateRestoreObjectResultDeserializer());
+        }
+    }
+}

--- a/sdk/Common/Communication/ServiceClientImpl.cs
+++ b/sdk/Common/Communication/ServiceClientImpl.cs
@@ -36,9 +36,22 @@ namespace Aliyun.OSS.Common.Communication
             
             public ExecutionContext Context { get; set; }
 
+            internal ServiceRequest Request { get; set; }
+
             public HttpAsyncResult(AsyncCallback callback, object state)
                 : base(callback, state)
             { }
+
+            protected override void Dispose(bool disposing)
+            {
+                base.Dispose(disposing);
+
+                if (disposing && Request != null)
+                {
+                    Request.Dispose();
+                    Request = null;
+                }
+            }
         }
 
         /// <summary>
@@ -177,7 +190,8 @@ namespace Aliyun.OSS.Common.Communication
             var asyncResult = new HttpAsyncResult(callback, state)
             {
                 WebRequest = request, 
-                Context = context
+                Context = context,
+                Request = serviceRequest
             };
 
             SetRequestContent(request, serviceRequest, true,

--- a/sdk/Common/Communication/ServiceRequest.cs
+++ b/sdk/Common/Communication/ServiceRequest.cs
@@ -49,7 +49,18 @@ namespace Aliyun.OSS.Common.Communication
         {
             get { return Content == null || Content.CanSeek; }
         }
-        
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this <see cref="T:Aliyun.OSS.Common.Communication.ServiceRequest"/>
+        /// use chunked encoding.
+        /// </summary>
+        /// <value><c>true</c> if use chunked encoding; otherwise, <c>false</c>.</value>
+        public bool UseChunkedEncoding
+        {
+            get;
+            set;
+        }
+
         /// <summary>
         /// Gets or sets a value indicating whether this <see cref="T:Aliyun.OSS.Common.Communication.ServiceRequest"/>
         /// parameters in URL.

--- a/sdk/Common/Communication/ServiceRequest.cs
+++ b/sdk/Common/Communication/ServiceRequest.cs
@@ -51,6 +51,17 @@ namespace Aliyun.OSS.Common.Communication
         }
         
         /// <summary>
+        /// Gets or sets a value indicating whether this <see cref="T:Aliyun.OSS.Common.Communication.ServiceRequest"/>
+        /// parameters in URL.
+        /// </summary>
+        /// <value><c>true</c> if parameters in URL; otherwise, <c>false</c>.</value>
+        public bool ParametersInUri
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// Build the request URI from the request message.
         /// </summary>
         /// <returns></returns>
@@ -101,7 +112,7 @@ namespace Aliyun.OSS.Common.Communication
         {
             var requestHasPayload = Content != null;
             var requestIsPost = Method == HttpMethod.Post;
-            var putParamsInUri = !requestIsPost || requestHasPayload;
+            var putParamsInUri = !requestIsPost || requestHasPayload || ParametersInUri;
             return putParamsInUri;
         }
         

--- a/sdk/Enums/StorageClass.cs
+++ b/sdk/Enums/StorageClass.cs
@@ -1,0 +1,15 @@
+﻿/*
+ * Copyright (C) Alibaba Cloud Computing
+ * All rights reserved.
+ * 
+ */
+using System;
+namespace Aliyun.OSS
+{
+    public enum StorageClass
+    {
+        Standard,
+        IA,
+        Archive
+    }
+}

--- a/sdk/Enums/StorageClass.cs
+++ b/sdk/Enums/StorageClass.cs
@@ -6,10 +6,13 @@
 using System;
 namespace Aliyun.OSS
 {
+    /// <summary>
+    /// Storage class of OSS Bucket
+    /// </summary>
     public enum StorageClass
     {
-        Standard,
-        IA,
-        Archive
+        Standard, // Standard bucket
+        IA,       // IA bucket
+        Archive   // Archive bucket
     }
 }

--- a/sdk/IOss.cs
+++ b/sdk/IOss.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Collections.Generic;
 using Aliyun.OSS.Common.Authentication;
 using Aliyun.OSS.Common.Internal;
+using Aliyun.OSS.Model;
 
 namespace Aliyun.OSS 
 {
@@ -53,6 +54,14 @@ namespace Aliyun.OSS
         /// <returns><see cref="Bucket" /> instance</returns>
         Bucket CreateBucket(string bucketName);
 
+        /// <summary>
+        /// Creates the bucket with specified storage class.
+        /// </summary>
+        /// <returns>The bucket.</returns>
+        /// <param name="bucketName">Bucket name.</param>
+        /// <param name="storageClass">Storage class.</param>
+        Bucket CreateBucket(string bucketName, StorageClass storageClass);
+       
         /// <summary>
         /// Deletes a empty bucket.If the bucket is not empty, this will fail.
         /// </summary>
@@ -655,6 +664,14 @@ namespace Aliyun.OSS
         /// <param name="key"><see cref="OssObject.Key" /></param>
         /// <returns><see cref="AccessControlList" /> instance</returns>
         AccessControlList GetObjectAcl(string bucketName, string key);
+
+        /// <summary>
+        /// Restores the object.
+        /// </summary>
+        /// <returns>The object.</returns>
+        /// <param name="bucketName">Bucket name.</param>
+        /// <param name="key">Key.</param>
+        RestoreObjectResult RestoreObject(string bucketName, string key);
 
         #endregion
         

--- a/sdk/IOss.cs
+++ b/sdk/IOss.cs
@@ -60,7 +60,7 @@ namespace Aliyun.OSS
         /// <returns>The bucket.</returns>
         /// <param name="bucketName">Bucket name.</param>
         /// <param name="storageClass">Storage class.</param>
-        Bucket CreateBucket(string bucketName, StorageClass storageClass);
+        Bucket CreateBucket(string bucketName, StorageClass? storageClass);
        
         /// <summary>
         /// Deletes a empty bucket.If the bucket is not empty, this will fail.

--- a/sdk/Model/CreateBucketRequestModel.cs
+++ b/sdk/Model/CreateBucketRequestModel.cs
@@ -1,0 +1,18 @@
+﻿/*
+ * Copyright (C) Alibaba Cloud Computing
+ * All rights reserved.
+ * 
+ */
+
+using System;
+using System.Xml.Serialization;
+
+namespace Aliyun.OSS.Model
+{
+    [XmlRoot("CreateBucketConfiguration")]
+    public class CreateBucketRequestModel
+    {
+        [XmlElement("StorageClass")]
+        public StorageClass StorageClass { get; set; }
+    }
+}

--- a/sdk/Model/RestoreObjectResult.cs
+++ b/sdk/Model/RestoreObjectResult.cs
@@ -1,0 +1,15 @@
+﻿/*
+ * Copyright (C) Alibaba Cloud Computing
+ * All rights reserved.
+ * 
+ */
+
+using System;
+using System.Xml.Serialization;
+
+namespace Aliyun.OSS.Model
+{
+    public class RestoreObjectResult : GenericResult
+    {
+    }
+}

--- a/sdk/OssClient.cs
+++ b/sdk/OssClient.cs
@@ -595,10 +595,8 @@ namespace Aliyun.OSS
             SetContentTypeIfNull(key, fileToUpload, ref metadata);
 
             IAsyncResult result;
-            using (Stream content = File.OpenRead(fileToUpload))
-            {
-                result = BeginPutObject(bucketName, key, content, metadata, callback, state);
-            }
+            Stream content = File.OpenRead(fileToUpload); // content will be disposed after EndPutObject is called;
+            result = BeginPutObject(bucketName, key, content, metadata, callback, state);
             return result;
         }
 

--- a/sdk/OssClient.cs
+++ b/sdk/OssClient.cs
@@ -19,6 +19,7 @@ using Aliyun.OSS.Common.Authentication;
 using Aliyun.OSS.Common.Communication;
 using Aliyun.OSS.Common.Handlers;
 using Aliyun.OSS.Common.Internal;
+using Aliyun.OSS.Model;
 using Aliyun.OSS.Properties;
 using Aliyun.OSS.Transform;
 using ExecutionContext = Aliyun.OSS.Common.Communication.ExecutionContext;
@@ -194,10 +195,16 @@ namespace Aliyun.OSS
         /// <inheritdoc/>
         public Bucket CreateBucket(string bucketName)
         {
+            return CreateBucket(bucketName, StorageClass.Standard);
+        }
+
+        /// <inheritdoc/>
+        public Bucket CreateBucket(string bucketName, StorageClass storageClass)
+        {
             var cmd = CreateBucketCommand.Create(_serviceClient, _endpoint,
                                                  CreateContext(HttpMethod.Put, bucketName, null),
-                                                 bucketName);
-            using(cmd.Execute())
+                                                 bucketName, storageClass);
+            using (cmd.Execute())
             {
                 // Do nothing
             }
@@ -1049,6 +1056,19 @@ namespace Aliyun.OSS
                                                  CreateContext(HttpMethod.Get, bucketName, key),
                                                  bucketName, 
                                                  key);
+            return cmd.Execute();
+        }
+
+        /// <inheritdoc/>
+        public RestoreObjectResult RestoreObject(string bucketName, string key)
+        {
+            ExecutionContext context = CreateContext(HttpMethod.Post, bucketName, key);
+            var cmd = RestoreObjectCommand.Create(_serviceClient,
+                                                 _endpoint,
+                                                  context,
+                                                 bucketName,
+                                                  key);
+
             return cmd.Execute();
         }
 

--- a/sdk/OssClient.cs
+++ b/sdk/OssClient.cs
@@ -195,11 +195,11 @@ namespace Aliyun.OSS
         /// <inheritdoc/>
         public Bucket CreateBucket(string bucketName)
         {
-            return CreateBucket(bucketName, StorageClass.Standard);
+            return CreateBucket(bucketName, null);
         }
 
         /// <inheritdoc/>
-        public Bucket CreateBucket(string bucketName, StorageClass storageClass)
+        public Bucket CreateBucket(string bucketName, StorageClass? storageClass)
         {
             var cmd = CreateBucketCommand.Create(_serviceClient, _endpoint,
                                                  CreateContext(HttpMethod.Put, bucketName, null),
@@ -1066,7 +1066,7 @@ namespace Aliyun.OSS
             var cmd = RestoreObjectCommand.Create(_serviceClient,
                                                  _endpoint,
                                                   context,
-                                                 bucketName,
+                                                  bucketName,
                                                   key);
 
             return cmd.Execute();

--- a/sdk/Transform/CreateBucketRequestSerializer.cs
+++ b/sdk/Transform/CreateBucketRequestSerializer.cs
@@ -1,0 +1,30 @@
+﻿/*
+ * Copyright (C) Alibaba Cloud Computing
+ * All rights reserved.
+ * 
+ */
+
+using System.IO;
+using Aliyun.OSS.Common.Communication;
+using Aliyun.OSS.Model;
+using Aliyun.OSS.Util;
+namespace Aliyun.OSS.Transform
+{
+    internal class CreateBucketRequestSerializer : RequestSerializer<StorageClass, CreateBucketRequestModel>
+    {
+        public CreateBucketRequestSerializer(ISerializer<CreateBucketRequestModel, Stream> contentSerializer)
+            : base(contentSerializer)
+        {
+        }
+
+        public override Stream Serialize(StorageClass request)
+        {
+            var model = new CreateBucketRequestModel
+            {
+                StorageClass = request
+            };
+
+            return ContentSerializer.Serialize(model);
+        }
+    }
+}

--- a/sdk/Transform/DeserializerFactory.cs
+++ b/sdk/Transform/DeserializerFactory.cs
@@ -141,6 +141,11 @@ namespace Aliyun.OSS.Transform
         {
             return new GetBucketLifecycleDeserializer(CreateContentDeserializer<LifecycleConfiguration>());
         }
+
+        public IDeserializer<ServiceResponse, RestoreObjectResult> CreateRestoreObjectResultDeserializer()
+        {
+            return new RestoreObjectResultDeserializer(CreateContentDeserializer<ErrorResult>());
+        }
     }
 
     internal class XmlDeserializerFactory : DeserializerFactory

--- a/sdk/Transform/RestoreObjectResultDeserializer.cs
+++ b/sdk/Transform/RestoreObjectResultDeserializer.cs
@@ -1,0 +1,27 @@
+﻿/*
+ * Copyright (C) Alibaba Cloud Computing
+ * All rights reserved.
+ * 
+ */
+
+using System.IO;
+using System.Collections.Generic;
+using Aliyun.OSS.Common.Communication;
+using Aliyun.OSS.Model;
+
+namespace Aliyun.OSS.Transform
+{
+    internal class RestoreObjectResultDeserializer : ResponseDeserializer<RestoreObjectResult, ErrorResult>
+    {
+        public RestoreObjectResultDeserializer(IDeserializer<Stream, ErrorResult> contentDeserializer)
+            : base(contentDeserializer)
+        { }
+
+        public override RestoreObjectResult Deserialize(ServiceResponse xmlStream)
+        {
+            RestoreObjectResult result = new RestoreObjectResult();
+            this.DeserializeGeneric(xmlStream, result);
+            return result;
+        }
+    }
+}

--- a/sdk/Transform/SerializerFactory.cs
+++ b/sdk/Transform/SerializerFactory.cs
@@ -58,6 +58,11 @@ namespace Aliyun.OSS.Transform
         {
             return new SetBucketLifecycleRequestSerializer(CreateContentSerializer<LifecycleConfiguration>());
         }
+
+        public ISerializer<StorageClass, Stream> CreateCreateBucketSerialization()
+        {
+            return new CreateBucketRequestSerializer(CreateContentSerializer<CreateBucketRequestModel>());
+        }
     }
 
     internal class XmlSerializerFactory : SerializerFactory

--- a/sdk/Util/OssRequestSigner.cs
+++ b/sdk/Util/OssRequestSigner.cs
@@ -32,8 +32,10 @@ namespace Aliyun.OSS.Util
             {
                 var canonicalString = SignUtils.BuildCanonicalString(httpMethod, resourcePath, request);
                 var signature = ServiceSignature.Create().ComputeSignature(accessKeySecret, canonicalString);
-                
-                request.Headers.Add(HttpHeaders.Authorization, "OSS " + accessKeyId + ":" + signature);
+
+                // request could be retried and the Authorization header may exist already.
+                // Fix for #OSS-1579/11349300 
+                request.Headers[HttpHeaders.Authorization] =  "OSS " + accessKeyId + ":" + signature;
             }
         }
     }

--- a/sdk/Util/OssUtils.cs
+++ b/sdk/Util/OssUtils.cs
@@ -345,10 +345,12 @@ namespace Aliyun.OSS.Util
         internal static TResult EndOperationHelper<TResult>(IServiceClient serviceClient, IAsyncResult asyncResult)
         {
             var response = EndOperationHelper(serviceClient, asyncResult);
-            var retryableAsyncResult = asyncResult as RetryableAsyncResult;
-            Debug.Assert(retryableAsyncResult != null);
-            OssCommand<TResult> cmd = (OssCommand<TResult>)retryableAsyncResult.Context.Command;
-            return cmd.DeserializeResponse(response);
+            using (RetryableAsyncResult retryableAsyncResult = asyncResult as RetryableAsyncResult)
+            {
+                Debug.Assert(retryableAsyncResult != null);
+                OssCommand<TResult> cmd = (OssCommand<TResult>)retryableAsyncResult.Context.Command;
+                return cmd.DeserializeResponse(response);
+            }
         }
 
         private static ServiceResponse EndOperationHelper(IServiceClient serviceClient, IAsyncResult asyncResult)

--- a/sdk/Util/RequestParameters.cs
+++ b/sdk/Util/RequestParameters.cs
@@ -16,6 +16,7 @@ namespace Aliyun.OSS.Util
         public const string SUBRESOURCE_UPLOADS = "uploads";
         public const string SUBRESOURCE_DELETE = "delete";
         public const string SUBRESOURCE_CORS = "cors";
+        public const string SUBRESOURCE_RESTORE = "restore";
     
         public const string PREFIX = "prefix";
         public const string DELIMITER = "delimiter";

--- a/sdk/Util/SignUtils.cs
+++ b/sdk/Util/SignUtils.cs
@@ -27,7 +27,7 @@ namespace Aliyun.OSS.Util
         private static readonly IList<string> ParamtersToSign = new List<string> {
             "acl", "uploadId", "partNumber", "uploads", "cors", "logging", 
             "website", "delete", "referer", "lifecycle", "security-token","append", 
-            "position", "x-oss-process",
+            "position", "x-oss-process", "restore", 
             ResponseHeaderOverrides.ResponseCacheControl,
             ResponseHeaderOverrides.ResponseContentDisposition,
             ResponseHeaderOverrides.ResponseContentEncoding,

--- a/sdk/aliyun-oss-sdk.csproj
+++ b/sdk/aliyun-oss-sdk.csproj
@@ -359,6 +359,12 @@
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
     <Compile Include="Common\ServiceException.cs" />
+    <Compile Include="Model\CreateBucketRequestModel.cs" />
+    <Compile Include="Enums\StorageClass.cs" />
+    <Compile Include="Transform\CreateBucketRequestSerializer.cs" />
+    <Compile Include="Commands\RestoreObjectCommand.cs" />
+    <Compile Include="Model\RestoreObjectResult.cs" />
+    <Compile Include="Transform\RestoreObjectResultDeserializer.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="aliyun_sdk_net.snk" />

--- a/test/TestCase/BucketTestCase/BucketBasicOperationTest.cs
+++ b/test/TestCase/BucketTestCase/BucketBasicOperationTest.cs
@@ -72,6 +72,52 @@ namespace Aliyun.OSS.Test.TestClass.BucketTestClass
                 string.Format("Bucket {0} should not exist after deletion", bucketName));
         }
 
+        [Test]
+        public void CreateAndDeleteIABucketTest()
+        {
+            //get a random bucketName
+            var bucketName = OssTestUtils.GetBucketName(_className);
+
+            //assert bucket does not exist
+            Assert.IsFalse(OssTestUtils.BucketExists(_ossClient, bucketName),
+                string.Format("Bucket {0} should not exist before creation", bucketName));
+
+            //create a new bucket
+            _ossClient.CreateBucket(bucketName, StorageClass.IA);
+            OssTestUtils.WaitForCacheExpire();
+            Assert.IsTrue(OssTestUtils.BucketExists(_ossClient, bucketName),
+                string.Format("Bucket {0} should exist after creation", bucketName));
+
+            //delete the new created bucket
+            _ossClient.DeleteBucket(bucketName);
+            OssTestUtils.WaitForCacheExpire();
+            Assert.IsFalse(OssTestUtils.BucketExists(_ossClient, bucketName),
+                string.Format("Bucket {0} should not exist after deletion", bucketName));
+        }
+
+        [Test]
+        public void CreateAndDeleteArchiveBucketTest()
+        {
+            //get a random bucketName
+            var bucketName = OssTestUtils.GetBucketName(_className);
+
+            //assert bucket does not exist
+            Assert.IsFalse(OssTestUtils.BucketExists(_ossClient, bucketName),
+                string.Format("Bucket {0} should not exist before creation", bucketName));
+
+            //create a new bucket
+            _ossClient.CreateBucket(bucketName, StorageClass.Archive);
+            OssTestUtils.WaitForCacheExpire();
+            Assert.IsTrue(OssTestUtils.BucketExists(_ossClient, bucketName),
+                string.Format("Bucket {0} should exist after creation", bucketName));
+
+            //delete the new created bucket
+            _ossClient.DeleteBucket(bucketName);
+            OssTestUtils.WaitForCacheExpire();
+            Assert.IsFalse(OssTestUtils.BucketExists(_ossClient, bucketName),
+                string.Format("Bucket {0} should not exist after deletion", bucketName));
+        }
+
         [Ignore]
         public void CreateAndDeleteBucketSecondRegionTest()
         {

--- a/test/TestCase/BucketTestCase/BucketBasicOperationTest.cs
+++ b/test/TestCase/BucketTestCase/BucketBasicOperationTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 using Aliyun.OSS;
 using Aliyun.OSS.Common;
@@ -88,6 +89,14 @@ namespace Aliyun.OSS.Test.TestClass.BucketTestClass
             Assert.IsTrue(OssTestUtils.BucketExists(_ossClient, bucketName),
                 string.Format("Bucket {0} should exist after creation", bucketName));
 
+            var objectName = bucketName + "firstobject";
+            _ossClient.PutObject(bucketName, objectName, new MemoryStream());
+
+            var objMeta = _ossClient.GetObjectMetadata(bucketName, objectName);
+
+            Assert.AreEqual(objMeta.HttpMetadata["x-oss-storage-class"], StorageClass.IA.ToString());
+            _ossClient.DeleteObject(bucketName, objectName);
+
             //delete the new created bucket
             _ossClient.DeleteBucket(bucketName);
             OssTestUtils.WaitForCacheExpire();
@@ -110,6 +119,14 @@ namespace Aliyun.OSS.Test.TestClass.BucketTestClass
             OssTestUtils.WaitForCacheExpire();
             Assert.IsTrue(OssTestUtils.BucketExists(_ossClient, bucketName),
                 string.Format("Bucket {0} should exist after creation", bucketName));
+
+            var objectName = bucketName + "firstobject";
+            _ossClient.PutObject(bucketName, objectName, new MemoryStream());
+
+            var objMeta = _ossClient.GetObjectMetadata(bucketName, objectName);
+
+            Assert.AreEqual(objMeta.HttpMetadata["x-oss-storage-class"], StorageClass.Archive.ToString());
+            _ossClient.DeleteObject(bucketName, objectName);
 
             //delete the new created bucket
             _ossClient.DeleteBucket(bucketName);

--- a/test/TestCase/ObjectTestCase/ObjectBasicOperationTest.cs
+++ b/test/TestCase/ObjectTestCase/ObjectBasicOperationTest.cs
@@ -107,7 +107,6 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
         }
 
         [Test]
-
         public void UploadObjectNullMetadataTest()
         {
             var key = OssTestUtils.GetObjectKey(_className);

--- a/test/TestCase/ObjectTestCase/ObjectCopyTest.cs
+++ b/test/TestCase/ObjectTestCase/ObjectCopyTest.cs
@@ -355,7 +355,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
 
                 var sourceObjectMeta = _ossClient.GetObjectMetadata(_bucketName, _sourceBigObjectKey);
 
-                _ossClient.ResumableCopyObject(copyRequest, null);
+                _ossClient.ResumableCopyObject(copyRequest, Config.DownloadFolder);
                 Assert.IsTrue(OssTestUtils.ObjectExists(_ossClient, _bucketName, targetObjectKey));
 
                 var targetObjectMeta = _ossClient.GetObjectMetadata(_bucketName, targetObjectKey);

--- a/test/TestCase/ObjectTestCase/ObjectHashCheckTest.cs
+++ b/test/TestCase/ObjectTestCase/ObjectHashCheckTest.cs
@@ -343,7 +343,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
         public void ResumableUploadEnableMD5Test()
         {
             // put little file
-            _ossClient.ResumableUploadObject(_bucketName, _objectKey, Config.UploadTestFile, null, null);
+            _ossClient.ResumableUploadObject(_bucketName, _objectKey, Config.UploadTestFile, null, Config.DownloadFolder);
             // check content md5
             OssTestUtils.DownloadObject(_ossClient, _bucketName, _objectKey, _tmpLocalFile);
             var expectedHashDigest = FileUtils.ComputeContentMd5(Config.UploadTestFile);
@@ -354,7 +354,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
             File.Delete(_tmpLocalFile);
 
             // put big file
-            _ossClient.ResumableUploadObject(_bucketName, _bigObjectKey, Config.MultiUploadTestFile, null, null, 1024 * 1024);
+            _ossClient.ResumableUploadObject(_bucketName, _bigObjectKey, Config.MultiUploadTestFile, null, Config.DownloadFolder, 1024 * 1024);
             // check content md5
             OssTestUtils.DownloadObject(_ossClient, _bucketName, _bigObjectKey, _tmpLocalFile);
             expectedHashDigest = FileUtils.ComputeContentMd5(Config.MultiUploadTestFile);
@@ -369,7 +369,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
         public void ResumableUploadDisableMD5Test()
         {
             // put little file
-            _ossClientDisableMD5.ResumableUploadObject(_bucketName, _objectKey, Config.UploadTestFile, null, null);
+            _ossClientDisableMD5.ResumableUploadObject(_bucketName, _objectKey, Config.UploadTestFile, null, Config.DownloadFolder);
             // check content md5
             OssTestUtils.DownloadObject(_ossClientDisableMD5, _bucketName, _objectKey, _tmpLocalFile);
             var expectedHashDigest = FileUtils.ComputeContentMd5(Config.UploadTestFile);
@@ -380,7 +380,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
             File.Delete(_tmpLocalFile);
 
             // put big file
-            _ossClientDisableMD5.ResumableUploadObject(_bucketName, _bigObjectKey, Config.MultiUploadTestFile, null, null, 1024 * 1024);
+            _ossClientDisableMD5.ResumableUploadObject(_bucketName, _bigObjectKey, Config.MultiUploadTestFile, null, Config.DownloadFolder, 1024 * 1024);
             // check content md5
             OssTestUtils.DownloadObject(_ossClientDisableMD5, _bucketName, _bigObjectKey, _tmpLocalFile);
             expectedHashDigest = FileUtils.ComputeContentMd5(Config.MultiUploadTestFile);

--- a/test/TestCase/ObjectTestCase/ObjectProgressTest.cs
+++ b/test/TestCase/ObjectTestCase/ObjectProgressTest.cs
@@ -215,7 +215,7 @@ namespace Aliyun.OSS.Test.TestClass.ObjectTestClass
         {
             var metadata = new ObjectMetadata();
             // resumable upload
-            _ossClient.ResumableUploadObject(_bucketName, _objectKey, Config.MultiUploadTestFile, metadata, null, 102410, uploadProgressCallback);
+            _ossClient.ResumableUploadObject(_bucketName, _objectKey, Config.MultiUploadTestFile, metadata, Config.DownloadFolder, 102410, uploadProgressCallback);
 
             // check md5
             OssTestUtils.DownloadObject(_ossClient, _bucketName, _objectKey, _tmpLocalFile);

--- a/test/Util/OssTestUtils.cs
+++ b/test/Util/OssTestUtils.cs
@@ -104,6 +104,20 @@ namespace Aliyun.OSS.Test.Util
             }
         }
 
+        public static IAsyncResult BeginUploadObject(IOss ossClient, string bucketName, 
+                                                    string objectKeyName, string originalFile, AsyncCallback callback, object callbackObject)
+        {
+            var metadata = new ObjectMetadata();
+            metadata.CacheControl = "No-Cache";
+            metadata.ContentType = "text/html";
+            return ossClient.BeginPutObject(bucketName, objectKeyName, originalFile, metadata, callback, callbackObject);
+        }
+
+        public static PutObjectResult EndUploadObject(IOss ossClient, IAsyncResult ar)
+        {
+            return ossClient.EndPutObject(ar);
+        }
+
         public static void MultiPartUpload(IOss ossClient, string bucketName,
             string objectKeyName, string originalFile, int numberOfParts, int totalSize)
         {


### PR DESCRIPTION
1 Supports IA/Archive in CreateBucket API.
  ---The original CreateBucket does not have the request body, which does not fully implement the PUT Bucket API spec.

2 Add Restore API.
