### PR TITLE
OssClient在win平台初始化失败解决

### DIFF
--- a/sdk/Common/Communication/ServiceClientImpl.cs
+++ b/sdk/Common/Communication/ServiceClientImpl.cs
@@ -480,11 +480,11 @@ namespace Aliyun.OSS.Common.Communication
                 // Specify the internal method name for adding headers
                 // mono: AddWithoutValidate
                 // win: AddInternal
-                var internalMethodName = (_isMonoPlatform == true) ? "AddWithoutValidate" : "AddInternal";
+                var internalMethodName = (_isMonoPlatform == true) ? "AddWithoutValidate" : "Add";
 
                 var mi = typeof(WebHeaderCollection).GetMethod(
                     internalMethodName,
-                    BindingFlags.NonPublic | BindingFlags.Instance,
+                    BindingFlags.Public | BindingFlags.Instance,
                     null,
                     new Type[] { typeof(string), typeof(string) },
                     null);


### PR DESCRIPTION
win 平台初始化OssClient 失败，原因是ServiceClientImpl反射调用WebHeaderCollection 的AddInternal方法不存在，已修改为调用Add方法