### PR TITLE
throw exception in asynchronous task

### DIFF
--- a/sdk/Common/Communication/netcore/ServiceClientNewImpl.cs
+++ b/sdk/Common/Communication/netcore/ServiceClientNewImpl.cs
@@ -246,9 +246,16 @@ namespace Aliyun.OSS.Common.Communication
             var task = client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead);
             ServiceClientImpl.HttpAsyncResult result = new ServiceClientImpl.HttpAsyncResult(callback, state);
             task.ContinueWith((resp) =>
-            {
-                ServiceResponse serviceResponse = new ResponseImpl(resp.Result);
-                result.Complete(serviceResponse);
+            {                
+                // Exception can't be caught outside because it happens in Task.ContinueWith
+                // Exception won't be rethrow here
+                if (resp.IsFaulted)
+                    result.Complete(resp.Exception);
+                else
+                {
+                    ServiceResponse serviceResponse = new ResponseImpl(resp.Result);
+                    result.Complete(serviceResponse);
+                }
             });
 
             return result;


### PR DESCRIPTION
If I use this BeginPutObject,BeginGetObject, the method wont rethrow the exception happens here. Easiest test should be disconnect internet, in comparison to GetObject(), an exception "No such host provider is know" should be thrown.